### PR TITLE
Utils File Refactoring Changes

### DIFF
--- a/cli/utils.py
+++ b/cli/utils.py
@@ -1,12 +1,13 @@
 import subprocess
 import os
 import pipes
-from rich.console import Console
-from rich.table import Column, Table
-from rich.panel import Panel
 
 import os.path
 from yaml import load, dump
+
+from rich.console import Console
+from rich.table import Table
+from rich.panel import Panel
 
 try:
     from yaml import CLoader as Loader, CDumper as Dumper
@@ -31,45 +32,45 @@ def write_yaml(data, filename):
         return yaml_string
 
 def console_yellow(text):
-    console.log(console.render_str(text, style='yellow'))
+    console.log(f'[yellow]{text}[/yellow]')
 
 def console_red(text):
-    console.log(console.render_str(text, style='red'))
+    console.log(f'[red]{text}[/red]')
 
 def call_system(cmd):
-    console.log(Panel('Command: %s' % cmd))
+    console.log(Panel(f'Command: {cmd}'))
 
-    code = os.system('/bin/bash -c %s' % pipes.quote(cmd))
+    code = os.system(f'/bin/bash -c {pipes.quote(cmd)}')
 
     if code != 0:
         raise SystemExit
 
 def call_docker(ctx, cmd):
-    call_command = 'docker %s' %(cmd)
+    call_command = f'docker {cmd}'
     call_system(call_command)
 
 def call_service(ctx, cmd):
-    call_command = 'docker service %s' % cmd
+    call_command = f'docker service {cmd}'
     call_system(call_command)
-    
+
 def call_compose(ctx, cmd):
-    args = ' '.join([
+    args = [
         '-f', 'docker-compose.yml',
         '-f', ctx.obj['docker_compose_file']
-    ])
+    ]
 
-    call_command = 'docker-compose %s %s' % (args, cmd)
+    call_command = f'docker-compose {" ".join(args)} {cmd}'
     call_system(call_command)
 
 def call_swarm(ctx, cmd):
-    compose_args = ' '.join([
+    compose_args = [
         '-f', 'docker-compose.yml',
         '-f', ctx.obj['docker_compose_file']
-    ])
+    ]
 
-    args = ' '.join([
-        '-c', '<(docker-compose %s config)' % compose_args,
-    ])
+    args = [
+        '-c', f'<(docker-compose {" ".join(compose_args)} config)',
+    ]
 
-    call_command = 'docker stack %s %s' % (cmd, args)
+    call_command = f'docker stack {cmd} {" ".join(args)}'
     call_system(call_command)


### PR DESCRIPTION
The changes made are mostly cosmetic and include:

Moving the rich imports to the top for better organization Using f-strings for string interpolation instead of the % operator Using lists instead of strings for building the command arguments and then joining them with spaces Changing the panel styles to use the [red] and [yellow] tags instead of console.render_str()